### PR TITLE
Update to upstream node:10.15.3-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.1-alpine
+FROM node:10.15.3-alpine
 LABEL maintainer="ISO Engineering <isodev@turner.com>"
 
 # Perform some setup

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FROM node:10.15.1-alpine
+FROM node:10.15.3-alpine
 LABEL maintainer="ISO Engineering <isodev@turner.com>"
 
 # Perform some setup


### PR DESCRIPTION
- Node 10.15.2 was a security release
- The 10.15.3 image switched to Alpine 3.9